### PR TITLE
build: update Gemfile with analytics plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "minima", "~> 2.5"
+
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-analytics", git: "https://github.com/groovecoder/jekyll-analytics.git"
+end

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal blog powered by Jekyll and hosted on GitHub Pages.
 
 ### Prerequisites
 
-- Ruby (version 2.5 or higher)
+- Ruby (version 2.7 or higher)
 - Bundler gem
 
 ### Setup


### PR DESCRIPTION
Updates the Gemfile to use Jekyll 4.3 and adds the jekyll-analytics plugin for build event tracking.

## Changes

- Pin Jekyll to ~> 4.3
- Add minima theme
- Add jekyll-feed and jekyll-seo-tag plugins
- Add jekyll-analytics from groovecoder fork

## Testing

```bash
bundle install
bundle exec jekyll serve
```